### PR TITLE
Add foxystreams and foxystreams.bitlord players.

### DIFF
--- a/direct.foxystreams.bitlord.json
+++ b/direct.foxystreams.bitlord.json
@@ -1,0 +1,12 @@
+{
+ "name"         : "foxystreams (BitLord Search)",
+ "plugin"       : "plugin.video.foxystreams",
+ "priority"     : 200,
+ "id"           : "direct.foxystreams-bitlord",
+ "movies"       : [[{
+  "link"      : "plugin://plugin.video.foxystreams/?scraper=BitLord&mode=movie&imdb={imdb}&title={title}&plot={plot}&genres={genres}&votes={votes}&rating={rating}&year={year}&mpaa={mpaa}&premiered={premiered}&original_title={original_title}&poster={poster}&fanart={fanart}"
+ }]],
+ "tvshows"      : [[{
+  "link"      : "plugin://plugin.video.foxystreams/?scraper=BitLord&mode=tv&id={id}&episode={episode}&season={season}&title={title}&plot={plot}&genres={genres}&votes={votes}&rating={rating}&year={year}&mpaa={mpaa}&firstaired={firstaired}&showname={showname}&poster={poster}&fanart={fanart}"
+ }]]
+}

--- a/direct.foxystreams.json
+++ b/direct.foxystreams.json
@@ -1,0 +1,12 @@
+{
+ "name"         : "foxystreams",
+ "plugin"       : "plugin.video.foxystreams",
+ "priority"     : 200,
+ "id"           : "direct.foxystreams",
+ "movies"       : [[{
+  "link"      : "plugin://plugin.video.foxystreams/?mode=movie&imdb={imdb}&title={title}&plot={plot}&genres={genres}&votes={votes}&rating={rating}&year={year}&mpaa={mpaa}&premiered={premiered}&original_title={original_title}&poster={poster}&fanart={fanart}&name={name}"
+ }]],
+ "tvshows"      : [[{
+  "link"      : "plugin://plugin.video.foxystreams/?mode=tv&id={id}&episode={episode}&season={season}&title={title}&plot={plot}&genres={genres}&votes={votes}&rating={rating}&year={year}&mpaa={mpaa}&firstaired={firstaired}&showname={showname}&poster={poster}&fanart={fanart}&name={name}"
+ }]]
+}


### PR DESCRIPTION
Two additional players, single addon, bitlord player considered secondary
backup search provider option.